### PR TITLE
Add go-build-flags flag

### DIFF
--- a/godockerize.go
+++ b/godockerize.go
@@ -188,8 +188,7 @@ func doBuild(c *cli.Context) error {
 
 	for _, importPath := range packages {
 		fmt.Printf("godockerize: Building Go binary %s...\n", path.Base(importPath))
-		flags := c.StringSlice("go-build-flags")
-		args := append([]string{"build"}, flags...)
+		args := append([]string{"build"}, c.StringSlice("go-build-flags")...)
 		args = append(args, "-buildmode", "exe", "-tags", "dist", "-o", path.Base(importPath), importPath)
 		cmd := exec.Command("go", args...)
 		cmd.Dir = tmpdir

--- a/godockerize.go
+++ b/godockerize.go
@@ -46,6 +46,10 @@ func main() {
 						Name:  "env",
 						Usage: "additional environment variables for the Dockerfile",
 					},
+					&cli.StringSliceFlag{
+						Name:  "go-build-flags",
+						Usage: "additional flags to pass to go build",
+					},
 					&cli.BoolFlag{
 						Name:  "dry-run",
 						Usage: "only print generated Dockerfile",
@@ -184,7 +188,10 @@ func doBuild(c *cli.Context) error {
 
 	for _, importPath := range packages {
 		fmt.Printf("godockerize: Building Go binary %s...\n", path.Base(importPath))
-		cmd := exec.Command("go", "build", "-buildmode", "exe", "-tags", "dist", "-o", path.Base(importPath), importPath)
+		flags := c.StringSlice("go-build-flags")
+		args := append([]string{"build"}, flags...)
+		args = append(args, "-buildmode", "exe", "-tags", "dist", "-o", path.Base(importPath), importPath)
+		cmd := exec.Command("go", args...)
 		cmd.Dir = tmpdir
 		cmd.Env = []string{
 			"GOARCH=amd64",
@@ -210,11 +217,7 @@ func doBuild(c *cli.Context) error {
 	cmd.Dir = tmpdir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Run()
 }
 
 func sortedStringSet(in []string) []string {


### PR DESCRIPTION
Add option to specify flags for go build. I anticipate using this to be able to embed the version in built binaries like: `-ldflags "-X github.com/sourcegraph/sourcegraph/pkg/version.version=1.2.3" \`

See https://github.com/sourcegraph/sourcegraph/pull/12193