### PR TITLE
Allow custom version repos to be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# godockerize
+
+godockerize builds a Dockerfile for a given Go project. The base image uses
+Alpine.
+
+### Usage
+
+```
+$ godockerize build github.com/path/to/your/go/main
+```
+
+Will generate a Dockerfile, build a Go binary for that package, and then build
+the Dockerfile with the Go binary.
+
+Run `--help` to view the full list of options for customizing the program's
+behavior.
+
+### Build tags
+
+godockerize supports a number of build tags that can be used to customize the
+content of the generated Dockerfile. Add a `//docker:<tagname>` comment line to
+the package being built to customize the behavior. Here are the tags:
+
+##### //docker:env
+
+Adding this to your Go binary:
+
+```go
+//docker:env TZ=UTC
+
+package main
+```
+
+Adds an ENV command to the dockerfile:
+
+```
+ENV TZ=UTC
+```
+
+##### //docker:expose
+
+Expose the provided ports via an EXPOSE command
+
+```go
+//docker:expose 5000
+```
+
+##### //docker:install
+
+Install the provided packages. In addition, if a package name ends with `@edge`,
+the edge apk repositories will be added to `/etc/apk/repositories`.
+
+```go
+//docker:install git@edge openssh-client
+```
+
+Generates:
+
+```
+  FROM alpine:3.8
+  RUN echo -e "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+  RUN echo -e "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+  RUN apk add --no-cache ca-certificates git@edge mailcap openssh-client tini
+  USER myuser
+  ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/mybinary"]
+  ADD mybinary /usr/local/bin/
+```
+
+##### //docker:repository
+
+Can be used to add other repository versions. Note as a special case, the `edge`
+repository is automatically added as part of the `docker:install` step for any
+packages that end in `@edge`.
+
+```go
+//docker:repository v3.6
+```
+
+Will add these lines to the Dockerfile:
+
+```
+  RUN echo -e "http://dl-cdn.alpinelinux.org/alpine/v3.6/main\n" >> /etc/apk/repositories && \
+    echo -e "http://dl-cdn.alpinelinux.org/alpine/v3.6/community\n" >> /etc/apk/repositories
+```
+
+##### //docker:run
+
+Add custom commands to run in the Dockerfile.
+
+```go
+//docker:run apk add curl
+```
+
+##### //docker:user
+
+Run commands in the Dockerfile as a custom user.
+
+```go
+//docker:user myuser
+```
+
+```
+RUN addgroup -S myuser && adduser -S -G myuser -h /home/myuser myuser && mkdir -p /data/repos && chown -R myuser:myuser /data/repos
+USER myuser
+```
+
+### Errata
+
+Alpine base images had a security vulnerability where apk installing/unpacking
+resources onto the filesystem could lead to RCE. That vulnerability has been
+fixed in Alpine 3.8.1. `godockerize` uses a base image that includes the
+security patch.

--- a/godockerize.go
+++ b/godockerize.go
@@ -88,13 +88,10 @@ func doBuild(c *cli.Context) error {
 	defer os.RemoveAll(tmpdir)
 
 	fset := token.NewFileSet()
-	packages := []string{}
+	var packages, expose, repos, run, userDirs []string
 	env := c.StringSlice("env")
-	expose := []string{}
 	install := []string{"ca-certificates", "mailcap", "tini"} // mailcap is for /etc/mime.types
-	run := []string{}
 	user := ""
-	userDirs := []string{}
 
 	for i, pkgName := range args.Slice() {
 		pkg, err := build.Import(pkgName, wd, 0)
@@ -112,7 +109,7 @@ func doBuild(c *cli.Context) error {
 			for _, cg := range f.Comments {
 				for _, c := range cg.List {
 					if strings.HasPrefix(c.Text, "//docker:") {
-						parts := strings.SplitN(c.Text[9:], " ", 2)
+						parts := strings.SplitN(c.Text[len("//docker:"):], " ", 2)
 						switch parts[0] {
 						case "env":
 							env = append(env, strings.Fields(parts[1])...)
@@ -120,6 +117,8 @@ func doBuild(c *cli.Context) error {
 							expose = append(expose, strings.Fields(parts[1])...)
 						case "install":
 							install = append(install, strings.Fields(parts[1])...)
+						case "repository":
+							repos = append(repos, strings.Fields(parts[1])...)
 						case "run":
 							run = append(run, parts[1])
 						case "user":
@@ -149,9 +148,16 @@ func doBuild(c *cli.Context) error {
 
 	for _, pkg := range install {
 		if strings.HasSuffix(pkg, "@edge") {
-			fmt.Fprintf(&dockerfile, "  RUN echo -e \"@edge http://dl-cdn.alpinelinux.org/alpine/edge/main\\n@edge http://dl-cdn.alpinelinux.org/alpine/edge/community\" >> /etc/apk/repositories\n")
+			fmt.Fprintf(&dockerfile, `  RUN echo -e "http://dl-cdn.alpinelinux.org/alpine/edge/main\n" >> /etc/apk/repositories && \
+    echo -e "http://dl-cdn.alpinelinux.org/alpine/edge/community\n" >> /etc/apk/repositories
+`)
 			break
 		}
+	}
+	for i := range repos {
+		fmt.Fprintf(&dockerfile, `  RUN echo -e "http://dl-cdn.alpinelinux.org/alpine/%s/main\n" >> /etc/apk/repositories && \
+    echo -e "http://dl-cdn.alpinelinux.org/alpine/%s/community\n" >> /etc/apk/repositories
+`, repos[i], repos[i])
 	}
 	if len(install) != 0 {
 		fmt.Fprintf(&dockerfile, "  RUN apk add --no-cache %s\n", strings.Join(sortedStringSet(install), " "))


### PR DESCRIPTION
Specify `//docker:repository v3.6` to add the v3.6 repository URL's
to /etc/apk/repositories.

Add a README describing each of the build tags and how they can be
used.