### PR TITLE
upgrade to github.com/urfave/cli@master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/sourcegraph/godockerize
 
 go 1.12
 
-require gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/urfave/cli v1.22.2-0.20191024042601-850de854cda0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,15 @@
-gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8 h1:Ggy3mWN4l3PUFPfSG0YB3n5fVYggzysUmiUQ89SnX6Y=
-gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8/go.mod h1:cKXr3E0k4aosgycml1b5z33BVV6hai1Kh7uDgFOkbcs=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
+github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli v1.22.2-0.20191024042601-850de854cda0 h1:F9D6tx2NI+LPI0fWSM7MwRBdtgP2XMxnx4qunWbGzO4=
+github.com/urfave/cli v1.22.2-0.20191024042601-850de854cda0/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/godockerize.go
+++ b/godockerize.go
@@ -17,7 +17,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/urfave/cli.v2"
+	"github.com/urfave/cli"
 )
 
 // Alpine doesn't do point releases, but if you are reading this, 3.8 downloads
@@ -30,7 +30,7 @@ func main() {
 		Name:    "godockerize",
 		Usage:   "build Docker images from Go packages",
 		Version: "0.0.2",
-		Commands: []*cli.Command{
+		Commands: []cli.Command{
 			{
 				Name:        "build",
 				Usage:       "build a Docker image from Go packages",
@@ -38,9 +38,8 @@ func main() {
 				Description: "Build compiles and installs the packages by the import paths to /usr/local/bin\n   in the docker image. The first package is used as the entrypoint.",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:    "tag",
-						Aliases: []string{"t"},
-						Usage:   "output Docker image name and optionally a tag in the 'name:tag' format",
+						Name:  "tag",
+						Usage: "output Docker image name and optionally a tag in the 'name:tag' format",
 					},
 					&cli.StringFlag{
 						Name:  "base",
@@ -79,7 +78,7 @@ func doBuild(c *cli.Context) error {
 	go111module, useModules := os.LookupEnv("GO111MODULE")
 
 	args := c.Args()
-	if args.Len() < 1 {
+	if len(args) < 1 {
 		return errors.New(`"godockerize build" requires 1 or more arguments`)
 	}
 
@@ -98,7 +97,7 @@ func doBuild(c *cli.Context) error {
 		install = []string{"ca-certificates", "mailcap", "tini"} // mailcap is for /etc/mime.types
 	)
 
-	for i, pkgName := range args.Slice() {
+	for i, pkgName := range args {
 		pkg, err := build.Import(pkgName, wd, 0)
 		if err != nil {
 			return err


### PR DESCRIPTION
According to https://github.com/urfave/cli/issues/826#issuecomment-552118603, the v2 of the github.com/urfave/cli package is now in master. Also updates a few places where the API changed.